### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/iam-credentials/latest",
   "api_id": "iamcredentials.googleapis.com",
   "distribution_name": "@google-cloud/iam-credentials",
-  "release_level": "GA",
+  "release_level": "preview",
   "default_version": "v1",
   "language": "nodejs",
   "name_pretty": "IAM Service Account Credentials API",
@@ -10,5 +10,7 @@
   "product_documentation": "",
   "requires_billing": true,
   "name": "iamcredentials",
-  "issue_tracker": "https://github.com/googleapis/nodejs-iam-credentials/issues"
+  "issue_tracker": "https://github.com/googleapis/nodejs-iam-credentials/issues",
+  "api_shortname": "iamcredentials",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "name": "iamcredentials",
   "issue_tracker": "https://github.com/googleapis/nodejs-iam-credentials/issues",
   "api_shortname": "iamcredentials",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be in **preview**. This means it is still a
+work-in-progress and under active development. Any release is subject to
+backwards-incompatible changes at any time.
+
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [IAM Service Account Credentials API: Node.js Client](https://github.com/googleapis/nodejs-iam-credentials)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/iam-credentials.svg)](https://www.npmjs.org/package/@google-cloud/iam-credentials)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-iam-credentials/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-iam-credentials)
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 